### PR TITLE
Purge exclusion

### DIFF
--- a/daily-report.py
+++ b/daily-report.py
@@ -1,6 +1,7 @@
 import os
 import json
 import argparse
+from libtools import *
 
 from dateutil.parser import parse
 from datetime import date, datetime, timedelta
@@ -68,26 +69,10 @@ parser.add_argument(
     help='list repositories stored in configuration file'
 )
 
-
-def get_config_path():
-    xdg_config_home_dir = os.environ.get('XDG_CONFIG_HOME', '')
-    home_dir = os.environ.get('HOME', '')
-    path = ""
-    if xdg_config_home_dir:
-        path = os.path.join(xdg_config_home_dir, SCRIPT_FOLDER)
-    elif home_dir:
-        path = os.path.join(home_dir, '.config', SCRIPT_FOLDER)
-    return path
-
-
-def get_config_file_full_path():
-    return os.path.join(get_config_path(), CONFIG_FILENAME)
-
-
 def get_options():
     options = {}
     try:
-        with open(get_config_file_full_path()) as config_file:
+        with open(get_config_file_full_path(SCRIPT_FOLDER, CONFIG_FILENAME)) as config_file:
             options = json.load(config_file)
     except FileNotFoundError:
         print("Error while reading options: file does not exist.")
@@ -95,9 +80,9 @@ def get_options():
 
 
 def save_options(options):
-    os.makedirs(get_config_path(), exist_ok=True)
+    os.makedirs(get_config_path(SCRIPT_FOLDER), exist_ok=True)
 
-    with open(get_config_file_full_path(), 'w') as config_file:
+    with open(get_config_file_full_path(SCRIPT_FOLDER, CONFIG_FILENAME), 'w') as config_file:
         json.dump(options, config_file)
 
 

--- a/libtools.py
+++ b/libtools.py
@@ -1,0 +1,16 @@
+# libtools.py
+import os
+
+def get_config_path(SCRIPT_FOLDER):
+    xdg_config_home_dir = os.environ.get('XDG_CONFIG_HOME', '')
+    home_dir = os.environ.get('HOME', '')
+    path = ""
+    if xdg_config_home_dir:
+        path = os.path.join(xdg_config_home_dir, SCRIPT_FOLDER)
+    elif home_dir:
+        path = os.path.join(home_dir, '.config', SCRIPT_FOLDER)
+    return path
+
+
+def get_config_file_full_path(SCRIPT_FOLDER, CONFIG_FILENAME):
+    return os.path.join(get_config_path(SCRIPT_FOLDER), CONFIG_FILENAME)

--- a/purge-branches.py
+++ b/purge-branches.py
@@ -41,13 +41,11 @@ def run():
     if git_process.returncode != 0:
         print("something wrong: %s" % git_process.stderr)
     else:
-        try:
-            with open(get_config_file_full_path(SCRIPT_FOLDER, CONFIG_FILENAME),
-                    'r') as config_file:
-                    exclusion_repos = config_file.read()
-            print(exclusion_repos)
-        except FileNotFoundError:
-            print("Error while reading options: file does not exist.")
+
+        # Get repos that is excluded from the purge
+        with open(get_config_file_full_path(SCRIPT_FOLDER, CONFIG_FILENAME),
+            'r+') as config_file:
+                exclusion_repos = config_file.read()
 
         
         all_repositories = [
@@ -55,12 +53,11 @@ def run():
             for repo in git_process.stdout.split("\n")
         ]
 
-        # cull to repos that need to be deleted
+        # filter repos to those that can be purged
         repositories = [repo for repo in all_repositories 
             if repo != "" and repo != "master" and not repo.startswith("* ")
                 and repo not in exclusion_repos
         ]
-        print(repositories)
 
         repo_count = len(repositories)
         if repo_count == 0:

--- a/purge-branches.py
+++ b/purge-branches.py
@@ -8,7 +8,7 @@ import argparse
 from libtools import *
 
 SCRIPT_FOLDER = 'git-tools'
-CONFIG_FILENAME = 'exclude-branch.json'
+CONFIG_FILENAME = 'purge-exclusion.txt'
 
 parser = argparse.ArgumentParser(
     description="Clear repository from unnecessary branches.",
@@ -44,7 +44,7 @@ def run():
 
         # Get repos that is excluded from the purge
         with open(get_config_file_full_path(SCRIPT_FOLDER, CONFIG_FILENAME),
-            'r+') as config_file:
+            'a+') as config_file:
                 exclusion_repos = config_file.read()
 
         


### PR DESCRIPTION
Solves #44. On first run, creates an empty file `~/.config/git-tools/purge-exclusion.txt`. That file can be modified to add line-separated branch names to be excluded from purging. Tested with `./purge-branches.py --dry-run` 

Things done
1. moved helper functions `daily-report.py` to a module called `libtools` to be used across both programs
2. added a purge-exclusion file

Things left to do
- [ ] Update docs